### PR TITLE
GanzInteractionZones->TalonInteractionZones

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -14,7 +14,7 @@ class TriggerType(Enum):
 
 # Functions
 def verify_home_dir()->str:
-    HOME_DIRECTORY = os.path.join(actions.path.talon_user(), 'GanzInteractionZones')
+    HOME_DIRECTORY = os.path.join(actions.path.talon_user(), 'TalonInteractionZones')
     if not os.path.exists(HOME_DIRECTORY):
         os.makedirs(HOME_DIRECTORY)
     return HOME_DIRECTORY

--- a/pdfparser/pdf_parser.py
+++ b/pdfparser/pdf_parser.py
@@ -2,7 +2,7 @@
 # Must run a standalone script
 if __name__ == "__main__":
     
-    CORRECT_FOLDER_NAME = "GanzInteractionZones"
+    CORRECT_FOLDER_NAME = "TalonInteractionZones"
     
     import fitz  # PyMuPDF
     from PIL import Image


### PR DESCRIPTION
When cloning this repository and running the installation instructions, you hit an error because the repo directory is a different name than is expected by CORRECT_FOLDER_NAME. This change sets CORRECT_FOLDER_NAME to match the name of the repository.